### PR TITLE
Null is empty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,7 @@ config.log
 config.status
 pkgIndex.tcl
 Makefile
-generic/*-gen*.c
+/generic/generated/
 *.ll
+/.cproject
+/.settings/

--- a/Makefile.in
+++ b/Makefile.in
@@ -174,7 +174,8 @@ AR		= @AR@
 CFLAGS		= @CFLAGS@
 COMPILE		= $(CC) $(LLVMCFLAGS) $(DEFS) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS)
 
-APIFILES	= ${srcdir}/generic/llvmtcl-gen.c ${srcdir}/generic/llvmtcl-gen-cmddef.c ${srcdir}/generic/llvmtcl-gen-map.c
+GENDIR		= ${srcdir}/generic/generated
+APIFILES	= ${GENDIR}/llvmtcl-gen.h ${GENDIR}/llvmtcl-gen-cmddef.h ${GENDIR}/llvmtcl-gen-map.h
 
 #========================================================================
 # Start of user-definable TARGETS section

--- a/Makefile.in
+++ b/Makefile.in
@@ -20,8 +20,8 @@
 #========================================================================
 
 #SAMPLE_NEW_VAR	= @SAMPLE_NEW_VAR@
-LLVMCOMPONENTS = 
-#core engine codegen all-targets native bitwriter mcjit linker interpreter
+LLVMCOMPONENTS = core engine codegen native bitwriter bitreader \
+	mcjit linker interpreter ipo
 LLVMCONFIG = @LLVMCONFIG@
 LLVMCFLAGS = `${LLVMCONFIG} --cxxflags`
 LLVMLFLAGS = `${LLVMCONFIG} --ldflags`

--- a/configure
+++ b/configure
@@ -8097,7 +8097,10 @@ $as_echo "${TCLSH_PROG}" >&6; }
 #TEA_PROG_WISH
 
 #--------------------------------------------------------------------
+# Determine where LLVM (really llvm-config) is and check that it's
+# possible to retrieve the information from it that we really need.
 #--------------------------------------------------------------------
+
 
 # Check whether --with-llvm-config was given.
 if test "${with_llvm_config+set}" = set; then :

--- a/configure.in
+++ b/configure.in
@@ -183,11 +183,9 @@ TEA_PROG_TCLSH
 #TEA_PROG_WISH
 
 #--------------------------------------------------------------------
+# Determine where LLVM (really llvm-config) is and check that it's
+# possible to retrieve the information from it that we really need.
 #--------------------------------------------------------------------
-AC_ARG_WITH(llvm-config,
-  [  --with-llvm-config=FILE],
-  [LLVMCONFIG=$withval],
-  [LLVMCONFIG=llvm-config])
 
 AC_ARG_WITH(llvm-config,
     AC_HELP_STRING([--with-llvm-config=FILE],

--- a/generic/llvmtcl.cpp
+++ b/generic/llvmtcl.cpp
@@ -45,7 +45,7 @@ std::string GetRefName(std::string prefix)
     return os.str();
 }
 
-#include "llvmtcl-gen-map.c"
+#include "generated/llvmtcl-gen-map.h"
 
 static const char *const intrinsicNames[] = {
 #define GET_INTRINSIC_NAME_TABLE
@@ -577,7 +577,7 @@ LLVMGetBasicBlocksObjCmd(
     return TCL_OK;
 }
 
-#include "llvmtcl-gen.c"
+#include "generated/llvmtcl-gen.h"
 
 static int
 LLVMCallInitialisePackageFunction(
@@ -828,7 +828,7 @@ DLLEXPORT int Llvmtcl_Init(Tcl_Interp *interp)
     if (Tcl_PkgProvide(interp, PACKAGE_NAME, PACKAGE_VERSION) != TCL_OK)
 	return TCL_ERROR;
 
-#include "llvmtcl-gen-cmddef.c"
+#include "generated/llvmtcl-gen-cmddef.h"
     LLVMObjCmd("llvmtcl::CreateGenericValueOfTclInterp", LLVMCreateGenericValueOfTclInterpObjCmd);
     LLVMObjCmd("llvmtcl::CreateGenericValueOfTclObj", LLVMCreateGenericValueOfTclObjObjCmd);
     LLVMObjCmd("llvmtcl::GenericValueToTclObj", LLVMGenericValueToTclObjObjCmd);

--- a/llvmtcl-gen.tcl
+++ b/llvmtcl-gen.tcl
@@ -477,9 +477,11 @@ set f [open $srcdir/llvmtcl-gen.inp r]
 set ll [split [read $f] \n]
 close $f
 
-set cf [open $srcdir/generic/llvmtcl-gen.c w]
-set of [open $srcdir/generic/llvmtcl-gen-cmddef.c w]
-set mf [open $srcdir/generic/llvmtcl-gen-map.c w]
+set targetdir $srcdir/generic/generated
+catch {file mkdir $targetdir} 
+set cf [open $targetdir/llvmtcl-gen.h w]
+set of [open $targetdir/llvmtcl-gen-cmddef.h w]
+set mf [open $targetdir/llvmtcl-gen-map.h w]
 
 foreach l $ll {
     set l [string trim $l]

--- a/llvmtcl-gen.tcl
+++ b/llvmtcl-gen.tcl
@@ -462,6 +462,7 @@ proc gen_map {mf l} {
     puts $mf "    return TCL_OK;"
     puts $mf "\}"
     puts $mf "Tcl_Obj* Set${tp}AsObj(Tcl_Interp* interp, $tp ref) \{"
+    puts $mf "    if (!ref) return Tcl_NewObj();"
     puts $mf "    if (${tp}_refmap.find(ref) == ${tp}_refmap.end()) \{"
     puts $mf "        std::string nm = GetRefName(\"${tp}_\");"
     puts $mf "        ${tp}_map\[nm\] = ref;"


### PR DESCRIPTION
This branch includes a few fixes to the configuration, and also the following key changes:

1. It puts the generated files in a subdirectory. It's just that bit less confusing that way!
2. It fixes the searching for intrinsics (alas, LLVM doesn't actually pre-sort the list in all its versions; they appear to be vacillating on the matter).
3. It makes it possible to tell when a reference value out of the API (e.g., a `UseRef`, which was my use case) is NULL, as those now become the empty string. Note that it was never safe to pass them back into the API before; it caused a crash because dereferencing NULL is generally a bad idea.

The third feature allows me to have code like this to garbage collect the functions in a module, which is very useful once you've done the inlining step:

<!-- language: lang-tcl -->

	while 1 {
	    # Find functions that we're not using. CAREFUL! Must not delete
	    # any functions that we define and which we export. But we can
	    # delete functions that are unreferenced and are either internal
	    # or declarations that we bring in from outside.

	    set first [GetFirstFunction $module]
	    set last [GetLastFunction $module]
	    set unwanted {}
	    for {set fn $first} {$fn ne $last} {set fn [GetNextFunction $fn]} {
		if {[GetFirstUse $fn] eq "" && (
			[GetVisibility $fn] eq "LLVMHiddenVisibility"
			|| [IsDeclaration $fn])} {
		    lappend unwanted $fn
		}
	    }

	    # Nothing meets the criteria? We're done...

	    if {![llength $unwanted]} {
		break
	    }

	    # Do the deletes when we're not iterating through the collection
	    # on the C++ side; I don't trust the iterator to be that safe.

	    foreach fn $unwanted {
		DeleteFunction $fn
	    }

	    # Note: there's a finite number of functions to start with, and we
	    # only get here if we deleted at least one of them, so this loop
	    # MUST terminate. But we must loop: deleting a function might have
	    # made more functions become unreferenced.
	}
